### PR TITLE
Properly quote argument to echo containging # in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -82,7 +82,7 @@ parser.c parser.h: parser.y boxes.h regexp/regexp.h
 
 lex.yy.c: lexer.l boxes.h
 	$(LEX) -t lexer.l > lexer.tmp.c
-	echo #include "config.h" > lex.yy.c
+	echo '#include "config.h"' > lex.yy.c
 	cat lexer.tmp.c >> lex.yy.c
 	rm lexer.tmp.c
 


### PR DESCRIPTION
lex.yy.c did not include config.h since the argument to echo was treated
as comment, so just an empty line was prepended.

Closes: #15