### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/src/misc/README.misc.md
+++ b/src/misc/README.misc.md
@@ -1,4 +1,4 @@
-###getopt Library
+### getopt Library
 
 This is used only for the Win32 build.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
