### PR TITLE
Fix some compiler warnings:

### DIFF
--- a/src/boxes.c
+++ b/src/boxes.c
@@ -1022,7 +1022,7 @@ static int list_styles()
         }
 
         fprintf (opt.outfile, "Minimum Box Dimensions: %d x %d  (width x height)\n",
-                d->minwidth, d->minheight);
+                (int) d->minwidth, (int) d->minheight);
 
         fprintf (opt.outfile, "Default Padding:        ");
         if (d->padding[BTOP] || d->padding[BRIG]


### PR DESCRIPTION
boxes.c:1024:31: warning: format ‘%d’ expects argument of type ‘int’,
but argument 3 has type ‘size_t {aka long unsigned int}’ [-Wformat=]

Signed-off-by: Stephen M. Cameron <stephenmcameron@gmail.com>