### PR TITLE
Update boxes-config with both f90 comments and box

### DIFF
--- a/boxes-config
+++ b/boxes-config
@@ -2881,7 +2881,7 @@ END important3
 # ============================================================================
 
 
-BOX fortran
+BOX f90-box
 
 author   "Matt Thompson <fortran(at)gmail(dot)com>"
 designer "(public domain)"
@@ -2906,7 +2906,35 @@ padding { h 1 }
 
 elastic (n,s,e, w)
 
-END fortran
+END f90-box
+
+
+# ============================================================================
+
+
+BOX f90-cmt
+
+author   "Matt Thompson <fortran(at)gmail(dot)com>"
+designer "(public domain)"
+revision "1.0"
+created  "2018-02-08"
+
+sample
+    !
+    !  regular comments used in Fortran 90+
+    !
+ends
+
+shapes {
+     w ("!")
+}
+
+padding { left 1}
+
+elastic (w)
+
+END f90-cmt
+
 
 # ============================================================================
 


### PR DESCRIPTION
The previous suggestion I made called `fortran` was for the box. However, older Fortran (i.e., FORTRAN 77) uses `c` as the comment character, not `!`. So, in case someone wants an `f77-box`, move the name to `f90-box`.

Also, a la the `ada-box` and `ada-cmt`, make a `f90-cmt` which does `!` commenting.

(NOTE: I'd have to review my F77, but since comment characters have to be in column 6, that might be exciting to program. Still, I rabidly avoid F77, so I leave that to others if required.)