### PR TITLE
Fix K&R C declaration to work with Clang16

### DIFF
--- a/src/remove.h
+++ b/src/remove.h
@@ -22,7 +22,7 @@
 
 
 int remove_box();
-void output_input();
+void output_input(const int trim_only);
 
 
 #endif /*REMOVE_H*/


### PR DESCRIPTION
By default Clang16 will not allow implicit function declarations, which would let this build fail with it.

Fix #106

I know this is a laughable PR, but since you asked for it in the issue... :D

Signed-off-by: Pascal Jaeger <pascal.jaeger@leimstift.de>