### PR TITLE
Boxes.el: Check that `boxes` v2.1.0 is available before using "-q (all)"

### DIFF
--- a/doc/boxes.el
+++ b/doc/boxes.el
@@ -77,6 +77,12 @@
   :type '(alist :key-type symbol :value-type string)
   :group 'boxes)
 
+(defconst boxes-minimum-version "2.1.0"
+  "Minimum required version of `boxes' to support querying the available box types.")
+
+(defconst boxes-version-regexp "\\([[:digit:]]+\\).\\([[:digit:]]+\\).\\([[:digit:]]+\\)"
+  "Regexp matching `boxes' version number.")
+
 (defvar boxes-history nil
   "Boxes types history.")
 
@@ -87,12 +93,30 @@
   "List of types available to the current boxes implementation, nil if not set yet.")
 
 (defun boxes-types ()
-  "Return the list of types available to the current boxes implementation."
+  "Return the list of types available to the current boxes implementation.
+Signal error if a supported version of `boxes' is not available."
   (or boxes-types-list
-      (setq boxes-types-list
-            (let ((types (process-lines boxes-command "-q" "(all)")))
-              (mapcar (lambda(type) (replace-regexp-in-string " *\(alias\) *$" "" type))
-                      types)))))
+      (and (or (boxes-check-version)
+               (error "Please install Boxes %s or later to support querying the available box types" boxes-minimum-version))
+           (setq boxes-types-list
+                 (let ((types (process-lines boxes-command "-q" "(all)")))
+                   (mapcar (lambda(type) (replace-regexp-in-string " *\(alias\) *$" "" type))
+                           types))))))
+
+(defun boxes-check-version ()
+  "Return t if a supported version of `boxes' is available, nil otherwise."
+  (let* ((version-output (car (process-lines boxes-command "-v")))
+         (version (boxes-version-to-list version-output))
+         (min-version (boxes-version-to-list boxes-minimum-version)))
+    (version-list-< min-version version)))
+
+(defun boxes-version-to-list (version)
+  "Convert VERSION string into a list of integers or nil if no match."
+  (and version
+       (string-match boxes-version-regexp version)
+       (list (string-to-number (match-string 1 version))
+             (string-to-number (match-string 2 version))
+             (string-to-number (match-string 3 version)))))
 
 (defun boxes-default-type (mode)
   "Get the default box type for the given buffer major MODE."
@@ -113,12 +137,20 @@
 ;;;###autoload
 (defun boxes-command-on-region (start end type &optional remove)
   "Create or Remove boxes from a region.
-To create a box select a region, hit \\[boxes-command-on-region] & enter a box type.
-Box type selection uses tab completion on the supported types.
-To remove a box simply prefix a 1 to the call, eg
-M-1 \\[boxes-command-on-region] will remove a box from a region.
-When calling from Lisp, supply the region START & END and the box TYPE to
-create a box.  Specifying a non-nil value for REMOVE, removes the box."
+
+To create a box select a region, hit \\[boxes-command-on-region]
+& enter a box type.  Box type selection uses tab completion on
+the supported types.
+
+To remove a box simply prefix a 1 to the call, eg M-1
+\\[boxes-command-on-region] will remove a box from a region.
+
+Note that interactive use requires `boxes' >= 2.1.0 to support
+querying the supported types.
+
+When calling from Lisp, supply the region START & END and the box
+TYPE to create a box.  Specifying a non-nil value for REMOVE,
+removes the box."
   (interactive (let ((string
 		      (completing-read (format "Box type (%s): " boxes-default-type)
 				       (boxes-types) nil t nil 'boxes-history boxes-default-type)))

--- a/doc/boxes.el
+++ b/doc/boxes.el
@@ -80,9 +80,6 @@
 (defconst boxes-minimum-version "2.1.0"
   "Minimum required version of `boxes' to support querying the available box types.")
 
-(defconst boxes-version-regexp "\\([[:digit:]]+\\).\\([[:digit:]]+\\).\\([[:digit:]]+\\)"
-  "Regexp matching `boxes' version number.")
-
 (defvar boxes-history nil
   "Boxes types history.")
 
@@ -95,28 +92,13 @@
 (defun boxes-types ()
   "Return the list of types available to the current boxes implementation.
 Signal error if a supported version of `boxes' is not available."
-  (or boxes-types-list
-      (and (or (boxes-check-version)
-               (error "Please install Boxes %s or later to support querying the available box types" boxes-minimum-version))
-           (setq boxes-types-list
-                 (let ((types (process-lines boxes-command "-q" "(all)")))
-                   (mapcar (lambda(type) (replace-regexp-in-string " *\(alias\) *$" "" type))
-                           types))))))
-
-(defun boxes-check-version ()
-  "Return t if a supported version of `boxes' is available, nil otherwise."
-  (let* ((version-output (car (process-lines boxes-command "-v")))
-         (version (boxes-version-to-list version-output))
-         (min-version (boxes-version-to-list boxes-minimum-version)))
-    (version-list-< min-version version)))
-
-(defun boxes-version-to-list (version)
-  "Convert VERSION string into a list of integers or nil if no match."
-  (and version
-       (string-match boxes-version-regexp version)
-       (list (string-to-number (match-string 1 version))
-             (string-to-number (match-string 2 version))
-             (string-to-number (match-string 3 version)))))
+  (condition-case nil
+      (or boxes-types-list
+          (setq boxes-types-list
+                (let ((types (process-lines boxes-command "-q" "(all)")))
+                  (mapcar (lambda(type) (replace-regexp-in-string " *\(alias\) *$" "" type))
+                          types))))
+    (error (error "Please install Boxes %s or later" boxes-minimum-version))))
 
 (defun boxes-default-type (mode)
   "Get the default box type for the given buffer major MODE."


### PR DESCRIPTION
● v2.1.0 is required to run boxes-command-on-region interactively due to requiring support for "-q (all)". The other commands work on all versions.

● Unfortunately `boxes` doesn't set a non-zero exit code when supplied with an invalid option, so I've added a check for the version number before using "-q (all)".