### PR TITLE
Add _DARWIN_C_SOURCE if APPLE

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -25,6 +25,10 @@
 
 #define _GNU_SOURCE
 
+#elif defined(__APPLE__)
+
+#define _DARWIN_C_SOURCE
+
 #elif defined(__sun__)
 
 #define _POSIX_SOURCE


### PR DESCRIPTION
Closes #118 

This PR adds `_DARWIN_C_SOURCE` in `src/config.h`. Testing shows that it allows boxes to be built from source (which is needed in non-standard brew installs, i.e., in `$HOME/.homebrew` say).

Seems to work for me.